### PR TITLE
Add websocket client support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { User } from './models/user'
 import { WithNavigate } from './utils/navigation'
 import { CssBaseline, CssVarsProvider } from '@mui/joy'
 import { preloadSounds } from './utils/sound'
+import WebSocketManager from './utils/websocket'
 
 type AppProps = WithNavigate
 
@@ -39,6 +40,7 @@ export class App extends React.Component<AppProps, AppState> {
     if (isTokenValid()) {
       this.loadUserProfile()
       preloadSounds();
+      WebSocketManager.getInstance().connect();
     }
   }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,5 +1,6 @@
 import { Login } from '@/api/auth'
 import { NavigationPaths } from './navigation'
+import WebSocketManager from './websocket'
 
 export const doLogin = async (
   email: string,
@@ -9,6 +10,7 @@ export const doLogin = async (
   const data = await Login(email, password)
   localStorage.setItem('ca_token', data.token)
   localStorage.setItem('ca_expiration', data.expiration)
+  WebSocketManager.getInstance().connect()
 
   const redirectUrl = localStorage.getItem('ca_redirect')
   if (redirectUrl) {

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -33,12 +33,11 @@ export class WebSocketManager {
 
     const wsProtocol = API_URL.startsWith('https') ? 'wss' : 'ws'
     const baseUrl = API_URL.replace(/^https?/, wsProtocol)
-    const url = `${baseUrl}/api/ws?token=${encodeURIComponent(token)}`
+    const url = `${baseUrl}/ws`
 
     try {
-      this.socket = new WebSocket(url)
-    } catch (err) {
-      console.error('WebSocket creation failed', err)
+      this.socket = new WebSocket(url, [wsProtocol, token])
+    } catch {
       this.scheduleReconnect()
       return
     }

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -1,0 +1,84 @@
+const API_URL = import.meta.env.VITE_APP_API_URL
+
+export class WebSocketManager {
+  private static instance: WebSocketManager
+  private socket: WebSocket | null = null
+  private retryCount = 0
+  private manualClose = false
+
+  private constructor() {}
+
+  static getInstance(): WebSocketManager {
+    if (!WebSocketManager.instance) {
+      WebSocketManager.instance = new WebSocketManager()
+    }
+    return WebSocketManager.instance
+  }
+
+  connect() {
+    const token = localStorage.getItem('ca_token')
+    if (!token) {
+      return
+    }
+
+    if (
+      this.socket &&
+      (this.socket.readyState === WebSocket.OPEN ||
+        this.socket.readyState === WebSocket.CONNECTING)
+    ) {
+      return
+    }
+
+    this.manualClose = false
+
+    const wsProtocol = API_URL.startsWith('https') ? 'wss' : 'ws'
+    const baseUrl = API_URL.replace(/^https?/, wsProtocol)
+    const url = `${baseUrl}/api/ws?token=${encodeURIComponent(token)}`
+
+    try {
+      this.socket = new WebSocket(url)
+    } catch (err) {
+      console.error('WebSocket creation failed', err)
+      this.scheduleReconnect()
+      return
+    }
+
+    this.socket.onopen = () => {
+      this.retryCount = 0
+    }
+
+    this.socket.onmessage = (event) => {
+      console.log('WebSocket message:', event.data)
+    }
+
+    this.socket.onclose = () => {
+      this.socket = null
+      this.scheduleReconnect()
+    }
+
+    this.socket.onerror = (event) => {
+      console.error('WebSocket error:', event)
+    }
+  }
+
+  disconnect() {
+    this.manualClose = true
+    if (this.socket) {
+      this.socket.close()
+      this.socket = null
+    }
+    this.retryCount = 0
+  }
+
+  private scheduleReconnect() {
+    if (this.manualClose) {
+      return
+    }
+
+    const delay = Math.min(30000, Math.pow(2, this.retryCount) * 1000)
+    this.retryCount += 1
+    setTimeout(() => this.connect(), delay)
+  }
+}
+
+export default WebSocketManager

--- a/src/views/Navigation/NavBar.tsx
+++ b/src/views/Navigation/NavBar.tsx
@@ -21,6 +21,7 @@ import { ThemeToggleButton } from '../Settings/ThemeToggleButton'
 import { NavBarLink } from './NavBarLink'
 import { getPathName, NavigationPaths, WithNavigate } from '@/utils/navigation'
 import { Logo } from '@/Logo'
+import WebSocketManager from '@/utils/websocket'
 
 type NavBarProps = WithNavigate
 
@@ -50,6 +51,7 @@ export class NavBar extends React.Component<NavBarProps, NavBarState> {
   private logout = () => {
     localStorage.removeItem('ca_token')
     localStorage.removeItem('ca_expiration')
+    WebSocketManager.getInstance().disconnect()
     this.props.navigate(NavigationPaths.Login)
   }
 


### PR DESCRIPTION
## Summary
- add WebSocketManager class to manage the single websocket
- connect to websocket after login and when refreshing with a valid token
- retry on disconnect and log incoming messages
- disconnect websocket when logging out

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6e9104c832a8b0e85b5e292d956