### PR TITLE
Add feature flags to settings

### DIFF
--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -1,0 +1,26 @@
+import { retrieveValue, storeValue } from '@/utils/storage'
+
+export interface FeatureFlagDefinition {
+  name: string
+  description: string
+  defaultValue: boolean
+}
+
+export const featureFlagDefinitions: FeatureFlagDefinition[] = [
+  {
+    name: 'useWebsockets',
+    description: 'Use websockets',
+    defaultValue: false,
+  },
+]
+
+export const FEATURE_FLAG_PREFIX = 'featureFlags.'
+
+export const getFeatureFlag = (
+  name: string,
+  defaultValue: boolean,
+): boolean => retrieveValue<boolean>(FEATURE_FLAG_PREFIX + name, defaultValue)
+
+export const setFeatureFlag = (name: string, value: boolean): void => {
+  storeValue<boolean>(FEATURE_FLAG_PREFIX + name, value)
+}

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -1,3 +1,5 @@
+import { getFeatureFlag } from '@/constants/featureFlags'
+
 const API_URL = import.meta.env.VITE_APP_API_URL
 
 export class WebSocketManager {
@@ -5,8 +7,11 @@ export class WebSocketManager {
   private socket: WebSocket | null = null
   private retryCount = 0
   private manualClose = false
+  private enabled: boolean
 
-  private constructor() {}
+  private constructor() {
+    this.enabled = getFeatureFlag('useWebsockets', false)
+  }
 
   static getInstance(): WebSocketManager {
     if (!WebSocketManager.instance) {
@@ -16,6 +21,9 @@ export class WebSocketManager {
   }
 
   connect() {
+    if (!this.enabled) {
+      return
+    }
     const token = localStorage.getItem('ca_token')
     if (!token) {
       return
@@ -70,7 +78,7 @@ export class WebSocketManager {
   }
 
   private scheduleReconnect() {
-    if (this.manualClose) {
+    if (this.manualClose || !this.enabled) {
       return
     }
 

--- a/src/views/Settings/FeatureFlagSettings.tsx
+++ b/src/views/Settings/FeatureFlagSettings.tsx
@@ -6,15 +6,17 @@ import {
   setFeatureFlag,
 } from '@/constants/featureFlags'
 
+interface FeatureFlagSettingsProps {}
+
 interface FeatureFlagSettingsState {
   flags: Record<string, boolean>
 }
 
 export class FeatureFlagSettings extends React.Component<
-  object,
+  FeatureFlagSettingsProps,
   FeatureFlagSettingsState
 > {
-  constructor(props: object) {
+  constructor(props: FeatureFlagSettingsProps) {
     super(props)
 
     const flags: Record<string, boolean> = {}

--- a/src/views/Settings/FeatureFlagSettings.tsx
+++ b/src/views/Settings/FeatureFlagSettings.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { Box, Typography, Divider, FormControl, Checkbox } from '@mui/joy'
+import {
+  featureFlagDefinitions,
+  getFeatureFlag,
+  setFeatureFlag,
+} from '@/constants/featureFlags'
+
+interface FeatureFlagSettingsState {
+  flags: Record<string, boolean>
+}
+
+export class FeatureFlagSettings extends React.Component<
+  object,
+  FeatureFlagSettingsState
+> {
+  constructor(props: object) {
+    super(props)
+
+    const flags: Record<string, boolean> = {}
+    featureFlagDefinitions.forEach(def => {
+      flags[def.name] = getFeatureFlag(def.name, def.defaultValue)
+    })
+
+    this.state = { flags }
+  }
+
+  private onToggle = (name: string) => {
+    const { flags } = this.state
+    const next = !flags[name]
+    this.setState({ flags: { ...flags, [name]: next } })
+    setFeatureFlag(name, next)
+  }
+
+  render(): React.ReactNode {
+    const { flags } = this.state
+    return (
+      <Box sx={{ mt: 2 }}>
+        <Typography level='h3'>Feature Flags</Typography>
+        <Divider />
+        {featureFlagDefinitions.map(def => (
+          <FormControl key={def.name} sx={{ mt: 1 }}>
+            <Checkbox
+              overlay
+              checked={flags[def.name]}
+              onChange={() => this.onToggle(def.name)}
+              label={def.description}
+            />
+          </FormControl>
+        ))}
+      </Box>
+    )
+  }
+}

--- a/src/views/Settings/FeatureFlagSettings.tsx
+++ b/src/views/Settings/FeatureFlagSettings.tsx
@@ -6,7 +6,7 @@ import {
   setFeatureFlag,
 } from '@/constants/featureFlags'
 
-interface FeatureFlagSettingsProps {}
+type FeatureFlagSettingsProps = object
 
 interface FeatureFlagSettingsState {
   flags: Record<string, boolean>

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -13,6 +13,7 @@ import { PassowrdChangeModal } from '../Modals/Inputs/PasswordChangeModal'
 import { APITokenSettings } from './APITokenSettings'
 import { NotificationSetting } from '../Notifications/NotificationSettings'
 import { ThemeToggle } from './ThemeToggle'
+import { FeatureFlagSettings } from './FeatureFlagSettings'
 import { storeValue } from '@/utils/storage'
 import { getHomeView, HomeView } from '@/utils/navigation'
 import { SelectValue } from '@mui/base'
@@ -115,6 +116,7 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
         </div>
         <NotificationSetting />
         <APITokenSettings />
+        <FeatureFlagSettings />
         <Box
           sx={{
             mt: 2,


### PR DESCRIPTION
## Summary
- create feature flag definitions and helper functions
- add FeatureFlagSettings component
- render FeatureFlagSettings in Settings page
- refine feature flag usage with websocket toggle
- fix default flag value and remove redundant checks

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68727a4aafcc832a899e7d321730c385