### PR TITLE
Add WSRequest type and WebSocket helpers

### DIFF
--- a/src/models/websocket.ts
+++ b/src/models/websocket.ts
@@ -1,0 +1,10 @@
+export type WSAction =
+  | 'get_user_labels'
+  | 'create_label'
+  | 'update_label'
+  | 'delete_label'
+
+export interface WSRequest {
+  Action: WSAction
+  Data?: unknown
+}

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -1,4 +1,5 @@
 import { getFeatureFlag } from '@/constants/featureFlags'
+import { WSRequest } from '@/models/websocket'
 
 const API_URL = import.meta.env.VITE_APP_API_URL
 
@@ -75,6 +76,17 @@ export class WebSocketManager {
       this.socket = null
     }
     this.retryCount = 0
+  }
+
+  isConnected(): boolean {
+    return this.socket !== null && this.socket.readyState === WebSocket.OPEN
+  }
+
+  send(request: WSRequest) {
+    if (!this.isConnected() || !this.socket) {
+      return
+    }
+    this.socket.send(JSON.stringify(request))
   }
 
   private scheduleReconnect() {

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -82,11 +82,12 @@ export class WebSocketManager {
     return this.socket !== null && this.socket.readyState === WebSocket.OPEN
   }
 
-  send(request: WSRequest) {
-    if (!this.isConnected() || !this.socket) {
-      return
+  send(request: WSRequest): void {
+    if (!this.isConnected()) {
+      throw new Error('WebSocket is not connected')
     }
-    this.socket.send(JSON.stringify(request))
+
+    this.socket!.send(JSON.stringify(request))
   }
 
   private scheduleReconnect() {


### PR DESCRIPTION
## Summary
- define `WSRequest` type describing messages sent via WebSocket
- extend `WebSocketManager` with `isConnected` and `send` helpers

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6872e5227674832ab928afbe43e9838f