### PR TITLE
Hide tasks overview on mobile

### DIFF
--- a/src/views/Navigation/NavBar.tsx
+++ b/src/views/Navigation/NavBar.tsx
@@ -20,6 +20,7 @@ import React from 'react'
 import { ThemeToggleButton } from '../Settings/ThemeToggleButton'
 import { NavBarLink } from './NavBarLink'
 import { getPathName, NavigationPaths, WithNavigate } from '@/utils/navigation'
+import { isMobile } from '@/utils/dom'
 import { Logo } from '@/Logo'
 import WebSocketManager from '@/utils/websocket'
 
@@ -113,11 +114,13 @@ export class NavBar extends React.Component<NavBarProps, NavBarState> {
                 icon={<LocalLibrary />}
                 label='My tasks'
               />
-              <NavBarLink
-                to={NavigationPaths.TasksOverview}
-                icon={<FormatListBulleted />}
-                label='Tasks Overview'
-              />
+              {!isMobile() && (
+                <NavBarLink
+                  to={NavigationPaths.TasksOverview}
+                  icon={<FormatListBulleted />}
+                  label='Tasks Overview'
+                />
+              )}
               <NavBarLink
                 to={NavigationPaths.Labels}
                 icon={<Label />}

--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -17,6 +17,7 @@ import { FeatureFlagSettings } from './FeatureFlagSettings'
 import { storeValue } from '@/utils/storage'
 import { getHomeView, HomeView } from '@/utils/navigation'
 import { SelectValue } from '@mui/base'
+import { isMobile } from '@/utils/dom'
 
 type SettingsProps = object
 type SettingsState = {
@@ -75,19 +76,23 @@ export class Settings extends React.Component<SettingsProps, SettingsState> {
             paddingBottom: '4',
           }}
         >
-          <Typography level='h3'>Preferred view</Typography>
-          <Divider />
-          <Typography>Choose your default view:</Typography>
-          <Select
-            value={homeView}
-            sx={{
-              maxWidth: '200px',
-            }}
-            onChange={this.onHomeViewChange}
-          >
-            <Option value='my_tasks'>My Tasks</Option>
-            <Option value='tasks_overview'>Tasks Overview</Option>
-          </Select>
+          {!isMobile() && (
+            <>
+              <Typography level='h3'>Preferred view</Typography>
+              <Divider />
+              <Typography>Choose your default view:</Typography>
+              <Select
+                value={homeView}
+                sx={{
+                  maxWidth: '200px',
+                }}
+                onChange={this.onHomeViewChange}
+              >
+                <Option value='my_tasks'>My Tasks</Option>
+                <Option value='tasks_overview'>Tasks Overview</Option>
+              </Select>
+            </>
+          )}
           <Typography
             level='h3'
             sx={{


### PR DESCRIPTION
## Summary
- hide Tasks Overview link on small screens
- hide Preferred view setting on mobile devices

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_687bccc6e99c832a91fc2450c21db137