### PR TITLE
Add deleteTask thunk and wire to components

### DIFF
--- a/src/store/tasksSlice.ts
+++ b/src/store/tasksSlice.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { GetTasks, GetTaskByID, MarkTaskComplete } from '@/api/tasks'
+import { GetTasks, GetTaskByID, MarkTaskComplete, DeleteTask } from '@/api/tasks'
 import { Task } from '@/models/task'
 import { RootState } from './store'
 
@@ -44,6 +44,11 @@ export const fetchTaskById = createAsyncThunk(
     const data = await GetTaskByID(id)
     return data.task
   },
+)
+
+export const deleteTask = createAsyncThunk(
+  'tasks/deleteTask',
+  async (taskId: string) => await DeleteTask(taskId),
 )
 
 const tasksSlice = createSlice({
@@ -119,6 +124,19 @@ const tasksSlice = createSlice({
         state.error = null
       })
       .addCase(completeTask.rejected, (state, action) => {
+        state.status = 'failed'
+        state.error = action.error.message ?? null
+      })
+      // Deleting tasks
+      .addCase(deleteTask.pending, state => {
+        state.status = 'loading'
+      })
+      .addCase(deleteTask.fulfilled, (state, action) => {
+        state.status = 'succeeded'
+        state.items = state.items.filter(t => t.id !== action.meta.arg)
+        state.error = null
+      })
+      .addCase(deleteTask.rejected, (state, action) => {
         state.status = 'failed'
         state.error = action.error.message ?? null
       })

--- a/src/views/Tasks/MyTasks.tsx
+++ b/src/views/Tasks/MyTasks.tsx
@@ -1,4 +1,5 @@
-import { DeleteTask, SkipTask, UpdateDueDate } from '@/api/tasks'
+import { SkipTask, UpdateDueDate } from '@/api/tasks'
+import { deleteTask } from '@/store/tasksSlice'
 import { Loading } from '@/Loading'
 import { TASK_UPDATE_EVENT } from '@/models/task'
 import {
@@ -46,13 +47,14 @@ import { ConfirmationModal } from '../Modals/Inputs/ConfirmationModal'
 import { DateModal } from '../Modals/Inputs/DateModal'
 import { addDays, addWeeks, endOfDay, endOfWeek } from 'date-fns'
 import WebSocketManager from '@/utils/websocket'
-import { RootState } from '@/store/store'
+import { AppDispatch, RootState } from '@/store/store'
 import { connect } from 'react-redux'
 import { TaskUI, MakeTaskUI, MarshallDate } from '@/utils/marshalling'
 
 type MyTasksProps = {
   userLabels: Label[]
   tasks: TaskUI[]
+  deleteTask: (taskId: string) => Promise<any>
 } & WithNavigate
 
 interface MyTasksState {
@@ -401,7 +403,7 @@ class MyTasksImpl extends React.Component<MyTasksProps, MyTasksState> {
     }
 
     if (isConfirmed === true) {
-      await DeleteTask(task.id)
+      await this.props.deleteTask(task.id)
 
       this.removeTask(task.id)
     }
@@ -662,7 +664,8 @@ const mapStateToProps = (state: RootState) => {
   }
 }
 
-const mapDispatchToProps = () => ({
+const mapDispatchToProps = (dispatch: AppDispatch) => ({
+  deleteTask: (taskId: string) => dispatch(deleteTask(taskId)),
 })
 
 export const MyTasks = connect(

--- a/src/views/Tasks/TaskEdit.tsx
+++ b/src/views/Tasks/TaskEdit.tsx
@@ -1,9 +1,9 @@
 import {
   CreateTask,
   SaveTask,
-  DeleteTask,
   SkipTask,
 } from '@/api/tasks'
+import { deleteTask } from '@/store/tasksSlice'
 import { Label } from '@/models/label'
 import { Frequency, Task } from '@/models/task'
 import { getTextColorFromBackgroundColor } from '@/utils/colors'
@@ -54,6 +54,7 @@ export type TaskEditProps = {
   defaultNotificationTriggers: NotificationTriggerOptions
 
   getTaskById: (id: string) => Promise<any>
+  deleteTask: (id: string) => Promise<any>
 } & WithNavigate
 
 type Errors = { [key: string]: string }
@@ -235,7 +236,7 @@ class TaskEditImpl extends React.Component<TaskEditProps, TaskEditState> {
 
   private onTaskDelete = async (taskId: string) => {
     try {
-      await DeleteTask(taskId)
+      await this.props.deleteTask(taskId)
       this.navigateAway()
     } catch {
       this.setState({
@@ -755,6 +756,7 @@ const mapStateToProps = (state: RootState) => {
 
 const mapDispatchToProps = (dispatch: AppDispatch) => ({
   getTaskById: (id: string) => dispatch(fetchTaskById(id)),
+  deleteTask: (id: string) => dispatch(deleteTask(id)),
 })
 
 export const TaskEdit = connect(

--- a/src/views/Tasks/TasksOverview.tsx
+++ b/src/views/Tasks/TasksOverview.tsx
@@ -1,7 +1,5 @@
-import {
-  DeleteTask,
-  UpdateDueDate,
-} from '@/api/tasks'
+import { UpdateDueDate } from '@/api/tasks'
+import { deleteTask } from '@/store/tasksSlice'
 import { getDueDateChipColor, getDueDateChipText } from '@/models/task'
 import {
   CancelRounded,
@@ -44,6 +42,7 @@ type TasksOverviewProps = {
   userLabels: Label[]
 
   completeTask: (taskId: string) => Promise<any>
+  deleteTask: (taskId: string) => Promise<any>
 } & WithNavigate
 
 interface TasksOverviewState {
@@ -289,7 +288,7 @@ class TasksOverviewImpl extends React.Component<
       throw new Error('Task to delete is not set')
     }
 
-    await DeleteTask(task.id)
+    await this.props.deleteTask(task.id)
   }
 
   render(): React.ReactNode {
@@ -463,6 +462,7 @@ const mapStateToProps = (state: RootState) => {
 
 const mapDispatchToProps = (dispatch: AppDispatch) => ({
   completeTask: (taskId: string) => dispatch(completeTask(taskId)),
+  deleteTask: (taskId: string) => dispatch(deleteTask(taskId)),
 })
 
 export const TasksOverview = connect(


### PR DESCRIPTION
## Summary
- add deleteTask thunk in tasksSlice
- handle deleteTask lifecycle in tasksSlice extraReducers
- wire deleteTask thunk to TasksOverview, MyTasks, and TaskEdit components
- replace direct DeleteTask API usage with thunk dispatch

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687d3030b4f4832aa990fbeb2f3dd0f5