### PR TITLE
Add skipTask thunk and update components

### DIFF
--- a/src/views/Tasks/MyTasks.tsx
+++ b/src/views/Tasks/MyTasks.tsx
@@ -1,7 +1,7 @@
-import { SkipTask, UpdateDueDate } from '@/api/tasks'
-import { deleteTask } from '@/store/tasksSlice'
+import { UpdateDueDate } from '@/api/tasks'
+import { skipTask, deleteTask } from '@/store/tasksSlice'
 import { Loading } from '@/Loading'
-import { TASK_UPDATE_EVENT } from '@/models/task'
+import { TASK_UPDATE_EVENT, Task } from '@/models/task'
 import {
   ExpandCircleDown,
   Add,
@@ -55,6 +55,7 @@ type MyTasksProps = {
   userLabels: Label[]
   tasks: TaskUI[]
   deleteTask: (taskId: string) => Promise<any>
+  skipTask: (taskId: string) => Promise<any>
 } & WithNavigate
 
 interface MyTasksState {
@@ -373,8 +374,8 @@ class MyTasksImpl extends React.Component<MyTasksProps, MyTasksState> {
       throw new Error('Attempted to skip a task without a reference')
     }
 
-    const response = await SkipTask(task.id)
-    const taskUI = MakeTaskUI(response.task, this.props.userLabels)
+    const response = await this.props.skipTask(task.id)
+    const taskUI = MakeTaskUI(response.payload as Task, this.props.userLabels)
 
     this.dismissMoreMenu()
     this.onTaskUpdated(task, taskUI, 'skipped')
@@ -666,6 +667,7 @@ const mapStateToProps = (state: RootState) => {
 
 const mapDispatchToProps = (dispatch: AppDispatch) => ({
   deleteTask: (taskId: string) => dispatch(deleteTask(taskId)),
+  skipTask: (taskId: string) => dispatch(skipTask(taskId)),
 })
 
 export const MyTasks = connect(

--- a/src/views/Tasks/TaskEdit.tsx
+++ b/src/views/Tasks/TaskEdit.tsx
@@ -1,9 +1,5 @@
-import {
-  CreateTask,
-  SaveTask,
-  SkipTask,
-} from '@/api/tasks'
-import { deleteTask } from '@/store/tasksSlice'
+import { CreateTask, SaveTask } from '@/api/tasks'
+import { skipTask, deleteTask } from '@/store/tasksSlice'
 import { Label } from '@/models/label'
 import { Frequency, Task } from '@/models/task'
 import { getTextColorFromBackgroundColor } from '@/utils/colors'
@@ -55,6 +51,7 @@ export type TaskEditProps = {
 
   getTaskById: (id: string) => Promise<any>
   deleteTask: (id: string) => Promise<any>
+  skipTask: (id: string) => Promise<any>
 } & WithNavigate
 
 type Errors = { [key: string]: string }
@@ -259,7 +256,7 @@ class TaskEditImpl extends React.Component<TaskEditProps, TaskEditState> {
       throw new Error('Attempted to skip while not editing a recurring task')
     }
 
-    SkipTask(taskId).then(() => {
+    this.props.skipTask(taskId).then(() => {
       this.navigateAway()
     })
   }
@@ -757,6 +754,7 @@ const mapStateToProps = (state: RootState) => {
 const mapDispatchToProps = (dispatch: AppDispatch) => ({
   getTaskById: (id: string) => dispatch(fetchTaskById(id)),
   deleteTask: (id: string) => dispatch(deleteTask(id)),
+  skipTask: (id: string) => dispatch(skipTask(id)),
 })
 
 export const TaskEdit = connect(


### PR DESCRIPTION
## Summary
- implement `skipTask` async thunk in `tasksSlice`
- handle skipTask lifecycle in extraReducers
- pass skipTask via Redux to MyTasks and TaskEdit
- replace direct API calls with redux actions

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_687d33344d40832aaa0a74730de5a5c0