### PR TITLE
Add updateDueDate redux thunk

### DIFF
--- a/src/store/tasksSlice.ts
+++ b/src/store/tasksSlice.ts
@@ -7,6 +7,7 @@ import {
   SkipTask,
   CreateTask,
   SaveTask,
+  UpdateDueDate,
 } from '@/api/tasks'
 import { Task } from '@/models/task'
 import { RootState } from './store'
@@ -75,6 +76,14 @@ export const createTask = createAsyncThunk(
 export const saveTask = createAsyncThunk(
   'tasks/saveTask',
   async (task: Task) => await SaveTask(task),
+)
+
+export const updateDueDate = createAsyncThunk(
+  'tasks/updateDueDate',
+  async ({ taskId, dueDate }: { taskId: string; dueDate: string }) => {
+    const response = await UpdateDueDate(taskId, dueDate)
+    return response.task
+  },
 )
 
 const tasksSlice = createSlice({
@@ -193,6 +202,30 @@ const tasksSlice = createSlice({
 
         state.status = 'succeeded'
         state.error = null
+      })
+      .addCase(skipTask.rejected, (state, action) => {
+        state.status = 'failed'
+        state.error = action.error.message ?? null
+      })
+      // Update due date
+      .addCase(updateDueDate.pending, state => {
+        state.status = 'loading'
+        state.error = null
+      })
+      .addCase(updateDueDate.fulfilled, (state, action) => {
+        const updatedTask = action.payload
+        const index = state.items.findIndex(t => t.id === updatedTask.id)
+        if (index >= 0) {
+          state.items[index] = updatedTask
+        } else {
+          state.items.push(updatedTask)
+        }
+        state.status = 'succeeded'
+        state.error = null
+      })
+      .addCase(updateDueDate.rejected, (state, action) => {
+        state.status = 'failed'
+        state.error = action.error.message ?? null
       })
       // Deleting tasks
       .addCase(deleteTask.pending, state => {

--- a/src/views/Tasks/MyTasks.tsx
+++ b/src/views/Tasks/MyTasks.tsx
@@ -1,5 +1,4 @@
-import { UpdateDueDate } from '@/api/tasks'
-import { skipTask, deleteTask } from '@/store/tasksSlice'
+import { skipTask, deleteTask, updateDueDate } from '@/store/tasksSlice'
 import { Loading } from '@/Loading'
 import { TASK_UPDATE_EVENT, Task } from '@/models/task'
 import {
@@ -56,6 +55,7 @@ type MyTasksProps = {
   tasks: TaskUI[]
   deleteTask: (taskId: string) => Promise<any>
   skipTask: (taskId: string) => Promise<any>
+  updateDueDate: (taskId: string, dueDate: string) => Promise<any>
 } & WithNavigate
 
 interface MyTasksState {
@@ -420,7 +420,10 @@ class MyTasksImpl extends React.Component<MyTasksProps, MyTasksState> {
       throw new Error('Attempted to delete without task reference')
     }
 
-    const response = await UpdateDueDate(task.id, MarshallDate(newDate))
+    const response = await this.props.updateDueDate(
+      task.id,
+      MarshallDate(newDate),
+    )
     const newTaskUI = MakeTaskUI(response.task, this.props.userLabels)
 
     this.onTaskUpdated(task, newTaskUI, 'rescheduled')
@@ -668,6 +671,8 @@ const mapStateToProps = (state: RootState) => {
 const mapDispatchToProps = (dispatch: AppDispatch) => ({
   deleteTask: (taskId: string) => dispatch(deleteTask(taskId)),
   skipTask: (taskId: string) => dispatch(skipTask(taskId)),
+  updateDueDate: (taskId: string, dueDate: string) =>
+    dispatch(updateDueDate({ taskId, dueDate })),
 })
 
 export const MyTasks = connect(

--- a/src/views/Tasks/TasksOverview.tsx
+++ b/src/views/Tasks/TasksOverview.tsx
@@ -1,5 +1,4 @@
-import { UpdateDueDate } from '@/api/tasks'
-import { deleteTask } from '@/store/tasksSlice'
+import { deleteTask, completeTask, updateDueDate } from '@/store/tasksSlice'
 import { getDueDateChipColor, getDueDateChipText } from '@/models/task'
 import {
   CancelRounded,
@@ -31,7 +30,6 @@ import { moveFocusToJoyInput } from '@/utils/joy'
 import { playSound, SoundEffect } from '@/utils/sound'
 import WebSocketManager from '@/utils/websocket'
 import { AppDispatch, RootState } from '@/store/store'
-import { completeTask } from '@/store/tasksSlice'
 import { connect } from 'react-redux'
 import { Label } from '@/models/label'
 import { sortTasksByDueDate } from '@/utils/grouping'
@@ -43,6 +41,7 @@ type TasksOverviewProps = {
 
   completeTask: (taskId: string) => Promise<any>
   deleteTask: (taskId: string) => Promise<any>
+  updateDueDate: (taskId: string, dueDate: string) => Promise<any>
 } & WithNavigate
 
 interface TasksOverviewState {
@@ -187,7 +186,10 @@ class TasksOverviewImpl extends React.Component<
     }
 
     const { userLabels } = this.props
-    const data = await UpdateDueDate(taskId, MarshallDate(date))
+    const data = await this.props.updateDueDate(
+      taskId,
+      MarshallDate(date),
+    )
     const newTaskUI = MakeTaskUI(data.task, userLabels)
 
     let newTasks = [...tasks]
@@ -463,6 +465,8 @@ const mapStateToProps = (state: RootState) => {
 const mapDispatchToProps = (dispatch: AppDispatch) => ({
   completeTask: (taskId: string) => dispatch(completeTask(taskId)),
   deleteTask: (taskId: string) => dispatch(deleteTask(taskId)),
+  updateDueDate: (taskId: string, dueDate: string) =>
+    dispatch(updateDueDate({ taskId, dueDate })),
 })
 
 export const TasksOverview = connect(


### PR DESCRIPTION
## Summary
- add `updateDueDate` async thunk in `tasksSlice`
- handle due date update in reducer
- connect thunk to `MyTasks` and `TasksOverview`

## Testing
- `yarn lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d3926e1d8832a82b53de952250ceb