### PR TITLE
Reset task draft on save

### DIFF
--- a/src/store/tasksSlice.ts
+++ b/src/store/tasksSlice.ts
@@ -325,6 +325,8 @@ const tasksSlice = createSlice({
         }
         groupTaskBy(task, state.groupedItems, state.groupBy)
 
+        state.draft = newTask()
+
         state.error = null
       })
       .addCase(createTask.rejected, (state, action) => {
@@ -353,6 +355,8 @@ const tasksSlice = createSlice({
 
         deleteTaskFromGroups(updatedTask.id, state.groupedItems)
         groupTaskBy(updatedTask, state.groupedItems, state.groupBy)
+
+        state.draft = newTask()
 
         state.error = null
       })


### PR DESCRIPTION
## Summary
- clear the task draft when creating or editing tasks succeeds

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6884f5380448832a916401c2fb411304