### PR TITLE
Add status slice and global UI notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { AppDispatch } from './store/store'
 import { connect } from 'react-redux'
 import { fetchUser } from './store/userSlice'
 import { fetchTokens } from './store/tokensSlice'
+import { StatusList } from './components/StatusList'
 import { fetchTasks, initGroups } from './store/tasksSlice'
 
 type AppProps = {
@@ -49,6 +50,7 @@ class AppImpl extends React.Component<AppProps> {
         >
           <NavBar navigate={navigate} />
           <Outlet />
+          <StatusList />
         </CssVarsProvider>
       </div>
     )

--- a/src/components/StatusList.tsx
+++ b/src/components/StatusList.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { Alert, IconButton, Snackbar } from '@mui/joy'
+import CloseIcon from '@mui/icons-material/Close'
+import { RootState, AppDispatch } from '@/store/store'
+import { Status, StatusSeverity } from '@/models/status'
+import { dismissStatus } from '@/store/statusSlice'
+
+interface StatusListProps {
+  statuses: Status[]
+  dismiss: (id: string) => void
+}
+
+class StatusListImpl extends React.Component<StatusListProps> {
+  private mapSeverity = (severity: StatusSeverity) => {
+    switch (severity) {
+      case 'error':
+        return 'danger'
+      case 'success':
+        return 'success'
+      case 'warning':
+        return 'warning'
+      default:
+        return 'primary'
+    }
+  }
+
+  render(): React.ReactNode {
+    const { statuses, dismiss } = this.props
+    const items = [...statuses]
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, 3)
+
+    return (
+      <>
+        {items.map(status => (
+          <Snackbar
+            key={status.id}
+            open={true}
+            autoHideDuration={status.timeout}
+            onClose={() => dismiss(status.id)}
+            sx={{ zIndex: 2000 }}
+          >
+            <Alert
+              color={this.mapSeverity(status.severity)}
+              variant='soft'
+              endDecorator={
+                <IconButton
+                  onClick={() => dismiss(status.id)}
+                  variant='plain'
+                  size='sm'
+                >
+                  <CloseIcon />
+                </IconButton>
+              }
+            >
+              {status.message}
+            </Alert>
+          </Snackbar>
+        ))}
+      </>
+    )
+  }
+}
+
+const mapStateToProps = (state: RootState) => ({
+  statuses: state.status.items,
+})
+
+const mapDispatchToProps = (dispatch: AppDispatch) => ({
+  dismiss: (id: string) => dispatch(dismissStatus(id)),
+})
+
+export const StatusList = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(StatusListImpl)

--- a/src/models/status.ts
+++ b/src/models/status.ts
@@ -1,0 +1,9 @@
+export type StatusSeverity = 'error' | 'success' | 'info' | 'warning'
+
+export interface Status {
+  id: string
+  message: string
+  severity: StatusSeverity
+  timeout?: number
+  createdAt: number
+}

--- a/src/store/statusSlice.ts
+++ b/src/store/statusSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction, nanoid } from '@reduxjs/toolkit'
+import { Status } from '@/models/status'
+
+export interface StatusState {
+  items: Status[]
+}
+
+const initialState: StatusState = {
+  items: [],
+}
+
+const statusSlice = createSlice({
+  name: 'status',
+  initialState,
+  reducers: {
+    addStatus: (state, action: PayloadAction<Status>) => {
+      state.items.push(action.payload)
+    },
+    dismissStatus: (state, action: PayloadAction<string>) => {
+      state.items = state.items.filter(status => status.id !== action.payload)
+    },
+  },
+})
+
+export const statusReducer = statusSlice.reducer
+const { addStatus, dismissStatus } = statusSlice.actions
+export { dismissStatus }
+
+export const pushStatus = (
+  status: Omit<Status, 'id' | 'createdAt'>,
+) => (dispatch: any) => {
+  const id = nanoid()
+  const createdAt = Date.now()
+  dispatch(addStatus({ ...status, id, createdAt }))
+  if (status.timeout) {
+    setTimeout(() => dispatch(dismissStatus(id)), status.timeout)
+  }
+  return id
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -4,6 +4,7 @@ import { tasksReducer } from './tasksSlice'
 import { labelsReducer } from './labelsSlice'
 import { userReducer } from './userSlice'
 import { tokensReducer } from './tokensSlice'
+import { statusReducer } from './statusSlice'
 
 export const store = configureStore({
   reducer: {
@@ -11,6 +12,7 @@ export const store = configureStore({
     labels: labelsReducer,
     user: userReducer,
     tokens: tokensReducer,
+    status: statusReducer,
   },
 })
 


### PR DESCRIPTION
## Summary
- create `status` model and Redux slice
- show a `StatusList` component with snackbars
- hook status slice into the store
- render `StatusList` in the app layout

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6884f9007538832ab63f49fc34c54b52