### PR TITLE
Fix creation bug where id isn't set correctly

### DIFF
--- a/src/store/tasksSlice.ts
+++ b/src/store/tasksSlice.ts
@@ -315,8 +315,8 @@ const tasksSlice = createSlice({
 
         const taskId = action.payload.task
         const task: Task = {
-          id: taskId,
           ...action.meta.arg,
+          id: taskId,
         }
 
         state.items.push(task)


### PR DESCRIPTION
id is overwritten by a -1 from action.meta.arg.id
so reverse the order since the arg is not the source of truth for this id