### PR TITLE
Keep group items sorted as they get rebucketed

### DIFF
--- a/src/views/Tasks/TasksOverview.tsx
+++ b/src/views/Tasks/TasksOverview.tsx
@@ -29,7 +29,6 @@ import { moveFocusToJoyInput } from '@/utils/joy'
 import { playSound, SoundEffect } from '@/utils/sound'
 import { AppDispatch, RootState } from '@/store/store'
 import { connect } from 'react-redux'
-import { sortTasksByDueDate } from '@/utils/grouping'
 import { TaskUI, MakeTaskUI, MarshallDate } from '@/utils/marshalling'
 
 type TasksOverviewProps = {
@@ -312,7 +311,7 @@ class TasksOverviewImpl extends React.Component<TasksOverviewProps> {
 
 const mapStateToProps = (state: RootState) => {
   const search = state.tasks.searchQuery
-  const tasks = sortTasksByDueDate(state.tasks.filteredItems.map(task => MakeTaskUI(task)))
+  const tasks = state.tasks.filteredItems.map(task => MakeTaskUI(task))
 
   return {
     search,


### PR DESCRIPTION
Items come in already sorted from the API but when recurring tasks get completed or other tasks get inserted from other clients, currently they would get appended to the groups they should be in. Despite initial reaction that this may be a terrible sort perf in some cases, since the array was presorted, we pretty much have insertion sort kind of performance when edits happen