### PR TITLE
feat(ws): handle token events

### DIFF
--- a/src/store/wsSlice.ts
+++ b/src/store/wsSlice.ts
@@ -1,6 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { SyncState } from '@/models/sync'
-import { registerWebSocketListeners as registerLabelsWs, unregisterWebSocketListeners as unregisterLabelsWs } from './labelsSlice'
+import {
+  registerWebSocketListeners as registerLabelsWs,
+  unregisterWebSocketListeners as unregisterLabelsWs,
+} from './labelsSlice'
+import {
+  registerWebSocketListeners as registerTokensWs,
+  unregisterWebSocketListeners as unregisterTokensWs,
+} from './tokensSlice'
 import WebSocketManager from '@/utils/websocket'
 
 export interface WSState {
@@ -31,6 +38,7 @@ const wsSlice = createSlice({
 
       const mgr = WebSocketManager.getInstance()
       registerLabelsWs(mgr)
+      registerTokensWs(mgr)
     },
     wsDisconnected: (state, action: PayloadAction<string | null>) => {
       state.status = 'failed'
@@ -39,6 +47,7 @@ const wsSlice = createSlice({
 
       const mgr = WebSocketManager.getInstance()
       unregisterLabelsWs(mgr)
+      unregisterTokensWs(mgr)
     },
   },
 })


### PR DESCRIPTION
## Summary
- sync tokens slice with websocket token events
- register token event listeners when websocket connects

## Testing
- `yarn lint && echo 'lint completed'`


------
https://chatgpt.com/codex/tasks/task_e_6891363dbf60832a9b2c62b169271fbc