### PR TITLE
Handle notification settings websocket updates

### DIFF
--- a/src/store/userSlice.ts
+++ b/src/store/userSlice.ts
@@ -1,8 +1,10 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { GetUserProfile, UpdateNotificationSettings } from '@/api/users'
 import { User } from '@/models/user'
 import { NotificationTriggerOptions, NotificationType } from '@/models/notifications'
 import { SyncState } from '@/models/sync'
+import WebSocketManager from '@/utils/websocket'
+import { store } from './store'
 
 export interface UserState {
   profile: User
@@ -42,7 +44,18 @@ export const updateNotificationSettings = createAsyncThunk(
 const userSlice = createSlice({
   name: 'user',
   initialState,
-  reducers: {},
+  reducers: {
+    notificationSettingsUpdated(
+      state,
+      action: PayloadAction<{
+        provider: NotificationType
+        triggers: NotificationTriggerOptions
+      }>,
+    ) {
+      state.profile.notifications.provider = action.payload.provider
+      state.profile.notifications.triggers = action.payload.triggers
+    },
+  },
   extraReducers: builder => {
     builder
       .addCase(fetchUser.pending, state => {
@@ -59,7 +72,47 @@ const userSlice = createSlice({
         state.status = 'failed'
         state.error = action.error.message ?? null
       })
+      .addCase(updateNotificationSettings.pending, state => {
+        state.status = 'loading'
+      })
+      .addCase(updateNotificationSettings.fulfilled, (state, action) => {
+        state.status = 'succeeded'
+        userSlice.caseReducers.notificationSettingsUpdated(state, {
+          payload: {
+            provider: action.meta.arg.type,
+            triggers: action.meta.arg.options,
+          },
+          type: 'user/notificationSettingsUpdated',
+        })
+        state.error = null
+      })
+      .addCase(updateNotificationSettings.rejected, (state, action) => {
+        state.status = 'failed'
+        state.error =
+          action.error.message ??
+          'An unknown error occurred while updating notification settings.'
+      })
   },
 })
 
 export const userReducer = userSlice.reducer
+
+const { notificationSettingsUpdated } = userSlice.actions
+
+const onNotificationSettingsUpdated = (data: unknown) => {
+  const settings = (data as any).settings ?? (data as any)
+  store.dispatch(
+    notificationSettingsUpdated({
+      provider: settings.provider,
+      triggers: settings.triggers,
+    }),
+  )
+}
+
+export const registerWebSocketListeners = (ws: WebSocketManager) => {
+  ws.on('notification_settings_updated', onNotificationSettingsUpdated)
+}
+
+export const unregisterWebSocketListeners = (ws: WebSocketManager) => {
+  ws.off('notification_settings_updated', onNotificationSettingsUpdated)
+}

--- a/src/store/wsSlice.ts
+++ b/src/store/wsSlice.ts
@@ -8,6 +8,10 @@ import {
   registerWebSocketListeners as registerTokensWs,
   unregisterWebSocketListeners as unregisterTokensWs,
 } from './tokensSlice'
+import {
+  registerWebSocketListeners as registerNotificationsWs,
+  unregisterWebSocketListeners as unregisterNotificationsWs,
+} from './userSlice'
 import WebSocketManager from '@/utils/websocket'
 
 export interface WSState {
@@ -39,6 +43,7 @@ const wsSlice = createSlice({
       const mgr = WebSocketManager.getInstance()
       registerLabelsWs(mgr)
       registerTokensWs(mgr)
+      registerNotificationsWs(mgr)
     },
     wsDisconnected: (state, action: PayloadAction<string | null>) => {
       state.status = 'failed'
@@ -48,6 +53,7 @@ const wsSlice = createSlice({
       const mgr = WebSocketManager.getInstance()
       unregisterLabelsWs(mgr)
       unregisterTokensWs(mgr)
+      unregisterNotificationsWs(mgr)
     },
   },
 })


### PR DESCRIPTION
## Summary
- add reducer and async handlers for notification settings updates
- hook websocket events to dispatch notification setting changes
- register notification listeners when websocket connects

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689136574a04832a95022ec7397fae16