### PR TITLE
chore: type reducer parameters

### DIFF
--- a/src/store/userSlice.ts
+++ b/src/store/userSlice.ts
@@ -99,8 +99,17 @@ export const userReducer = userSlice.reducer
 
 const { notificationSettingsUpdated } = userSlice.actions
 
-const onNotificationSettingsUpdated = (data: unknown) => {
-  const settings = (data as any).settings ?? (data as any)
+interface NotificationSettingsPayload {
+  provider: NotificationType
+  triggers: NotificationTriggerOptions
+}
+
+type NotificationSettingsEvent =
+  | { settings: NotificationSettingsPayload }
+  | NotificationSettingsPayload
+
+const onNotificationSettingsUpdated = (data: NotificationSettingsEvent) => {
+  const settings = 'settings' in data ? data.settings : data
   store.dispatch(
     notificationSettingsUpdated({
       provider: settings.provider,


### PR DESCRIPTION
## Summary
- add explicit action and state types to token and label reducers
- replace `any` casts in WebSocket handlers with typed interfaces
- strengthen notification settings listener typing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68913b3d5a54832aac6deab6425ea639